### PR TITLE
Add mobile order + loyalty feature preview mockup

### DIFF
--- a/app/components/FeaturePreview.tsx
+++ b/app/components/FeaturePreview.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+interface FeaturePreviewProps {
+  userEmail?: string;
+  productCount: number;
+}
+
+export default function FeaturePreview({
+  userEmail,
+  productCount,
+}: FeaturePreviewProps) {
+  const firstName = userEmail?.split("@")[0] ?? "there";
+
+  return (
+    <section className="mb-8 rounded-xl border border-amber-200 bg-gradient-to-r from-amber-50 via-orange-50 to-rose-50 p-6 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+            Feature Preview
+          </p>
+          <h2 className="mt-1 text-2xl font-bold text-gray-900">
+            Mobile Order Ahead + Loyalty Wallet
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm text-gray-700">
+            Hi {firstName}, we are testing a faster checkout flow that lets
+            regulars save favorites, reorder in one tap, and track points
+            toward free drinks.
+          </p>
+          <p className="mt-2 text-sm text-gray-600">
+            {productCount} menu items are currently eligible in the beta menu.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-amber-300 bg-white/80 p-4 text-sm text-gray-700">
+          <p className="font-semibold text-gray-900">Pilot status</p>
+          <p className="mt-1">Internal mockup only</p>
+          <button
+            type="button"
+            disabled
+            className="mt-3 w-full cursor-not-allowed rounded bg-amber-500 px-4 py-2 font-medium text-white opacity-70"
+          >
+            Join Waitlist (coming soon)
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "./components/AuthContext";
 import AuthForm from "./components/AuthForm";
 import ProductCard from "./components/ProductCard";
 import Cart from "./components/Cart";
+import FeaturePreview from "./components/FeaturePreview";
 
 interface Product {
   id: number;
@@ -200,6 +201,8 @@ export default function Home() {
       </header>
 
       <main className="container mx-auto px-4 py-8">
+        <FeaturePreview userEmail={user.email} productCount={products.length} />
+
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {products.map((product) => (
             <ProductCard


### PR DESCRIPTION
## Summary
- Add a new `FeaturePreview` storefront section that mocks a mobile order-ahead and loyalty wallet experience.
- Personalize the preview copy using the signed-in user's email handle and show dynamic beta-eligible menu count.
- Keep the feature intentionally non-functional (`Join Waitlist` disabled) so this acts as a realistic UI-only product mockup PR.

## Test plan
- [x] `npm run lint`
- [ ] Run app locally and confirm preview appears for authenticated users on home page

Made with [Cursor](https://cursor.com)